### PR TITLE
Fix: Update PHP version in release workflow to 8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.1'
           extensions: mbstring, xml, ctype, iconv, json, pdo, curl
           tools: composer:v2
 


### PR DESCRIPTION
The release workflow's 'build' job was failing during `composer install --no-dev` because it was using PHP 8.0. Your project's `composer.json` (via `laravel/framework: 10.*` in `require-dev`) requires PHP ^8.1 for its dependency resolution, even when installing with --no-dev.

This commit updates the `php-version` in the release workflow's 'build' job from '8.0' to '8.1', ensuring a compatible environment for dependency installation.

## Description
Provide a detailed description of the changes in this pull request.

## Related Issue
Fixes #(issue number)

## Type of Change
Please mark the appropriate option:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Tests

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes:
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Information
Any additional information, screenshots, or context about the changes. 