### PR TITLE
Fix: Grant contents:write permission to release workflow job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
The release workflow was failing at the 'Create release' step (using softprops/action-gh-release@v1) with an error "HttpError: Resource not accessible by integration". This is typically due to the GITHUB_TOKEN having insufficient permissions.

This commit adds the `permissions: { contents: write }` block to the `build` job in `.github/workflows/release.yml`. This explicitly grants the job the necessary permissions to create a GitHub release and upload assets.

## Description
Provide a detailed description of the changes in this pull request.

## Related Issue
Fixes #(issue number)

## Type of Change
Please mark the appropriate option:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Tests

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes:
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual tests

## Checklist:
- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Information
Any additional information, screenshots, or context about the changes. 